### PR TITLE
Add filters as customization option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
-        "html2canvas-pro": "^1.5.8",
+        "html-to-image": "^1.11.13",
         "next": "15.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -80,9 +80,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.0.tgz",
-      "integrity": "sha512-H+N/FqT07NmLmt6OFFtDfwe8PNygprzBikrEMyQfgqSmT0vzE515Pz7R8izwB9q/zsH/MA64AKoul3sA6/CzVg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-4JFstCTaToCFrPqrGzgkF8N2NHjtsaY4uRh6brZQ5L9e4wbMieX8oDT8N7qfVFTQecHFEtkj4ve49VIZ3mKVqw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.0.tgz",
-      "integrity": "sha512-64WYIf4UYcdLnbKn/umDlNjQDSS8AgZrI/R9+x5ilkUVFxXcA1Ebl+gQLc/6mERA4407Xof0R7wEyEuj091CVw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.1.tgz",
+      "integrity": "sha512-LMshMVP0ZhACNjQNYXiU1iZJ6QCcv0lUdPDPugqGvCGXt5xtRVBPdtA0qU12pEXZzpWAhWlZYptfdAFq10DOVQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
-      "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.0.tgz",
+      "integrity": "sha512-WhCn7Z7TauhBtmzhvKpoQs0Wwb/kBcy4CwpuI0/eEIr2Lx2auxmulAzLr91wVZJaz47iUZdkXOK7WlAfxGKCnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1977,15 +1977,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2189,15 +2180,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -3417,18 +3399,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/html2canvas-pro": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/html2canvas-pro/-/html2canvas-pro-1.5.8.tgz",
-      "integrity": "sha512-bVGAU7IvhBwBlRAmX6QhekX8lsaxmYoF6zIwf/HNlHscjx+KN8jw/U4PQRYqeEVm9+m13hcS1l5ChJB9/e29Lw==",
-      "license": "MIT",
-      "dependencies": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -5477,15 +5452,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
@@ -5743,15 +5709,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
-    "html2canvas-pro": "^1.5.8",
+    "html-to-image": "^1.11.13",
     "next": "15.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/components/pages/CustomizePage/CustomizePage.tsx
+++ b/src/components/pages/CustomizePage/CustomizePage.tsx
@@ -1,5 +1,10 @@
 import { useCustomize } from "@/hooks/useCustomize";
-import { BACKGROUND_COLORS } from "@/types/constants";
+import {
+  BACKGROUND_COLORS,
+  backgroundColorToClass,
+  FILTERS,
+  filterToClass,
+} from "@/types/constants";
 
 type CustomizePageProps = {
   selectedPictures: string[];
@@ -8,6 +13,8 @@ const CustomizePage = ({ selectedPictures }: CustomizePageProps) => {
   const {
     backgroundColor,
     setBackgroundColor,
+    filter,
+    setFilter,
     downloadableImageRef,
     handleDownloadImage,
   } = useCustomize();
@@ -16,12 +23,14 @@ const CustomizePage = ({ selectedPictures }: CustomizePageProps) => {
       <div className="flex flex-col w-fit">
         <div
           ref={downloadableImageRef}
-          className={`flex flex-col w-min gap-3 bg-${backgroundColor}-500 px-3 py-7`}
+          className={`flex flex-col w-min gap-3 ${backgroundColorToClass.get(
+            backgroundColor
+          )} px-3 py-7`}
         >
           {selectedPictures.map((picture, index) => (
             // eslint-disable-next-line @next/next/no-img-element
             <img
-              className="min-w-[160px]"
+              className={`min-w-[160px] ${filterToClass.get(filter)}`}
               key={index}
               src={picture}
               alt="picture"
@@ -46,6 +55,19 @@ const CustomizePage = ({ selectedPictures }: CustomizePageProps) => {
                 onChange={(e) => setBackgroundColor(e.target.value)}
               />
               {color}
+            </label>
+          ))}
+        </fieldset>
+        <fieldset>
+          {FILTERS.map((filterName) => (
+            <label key={filterName}>
+              <input
+                type="radio"
+                value={filterName}
+                checked={filter === filterName}
+                onChange={(e) => setFilter(e.target.value)}
+              />
+              {filterName}
             </label>
           ))}
         </fieldset>

--- a/src/hooks/useCustomize.ts
+++ b/src/hooks/useCustomize.ts
@@ -1,32 +1,31 @@
 import { useState, useRef } from "react";
-import html2canvas from "html2canvas-pro";
+import { toPng } from "html-to-image";
 
 export const useCustomize = () => {
   const [backgroundColor, setBackgroundColor] = useState("sky");
+  const [filter, setFilter] = useState("none");
   const downloadableImageRef = useRef<HTMLDivElement>({} as HTMLDivElement);
 
-  const handleDownloadImage = async () => {
-    const element = downloadableImageRef.current;
-    const canvas = await html2canvas(element);
-
-    const data = canvas.toDataURL("image/jpg");
-    const link = document.createElement("a");
-
-    if (typeof link.download === "string") {
-      link.href = data;
-      link.download = "image.jpg";
-
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    } else {
-      window.open(data);
-    }
+  const handleDownloadImage = () => {
+    toPng(downloadableImageRef.current, { cacheBust: false, skipFonts: true })
+      .then((dataUrl) => {
+        const link = document.createElement("a");
+        link.download = `rosy-photo-booth-${new Date().toLocaleDateString(
+          "en-US"
+        )}.png`;
+        link.href = dataUrl;
+        link.click();
+      })
+      .catch((err) => {
+        console.log(err);
+      });
   };
 
   return {
     backgroundColor,
     setBackgroundColor,
+    filter,
+    setFilter,
     downloadableImageRef,
     handleDownloadImage,
   };

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -1,3 +1,17 @@
 export const PICTURE_COUNT = 4;
 
 export const BACKGROUND_COLORS = ["sky", "yellow", "pink"];
+
+export const backgroundColorToClass = new Map<string, string>([
+  ["sky", "bg-sky-500"],
+  ["yellow", "bg-yellow-500"],
+  ["pink", "bg-pink-500"],
+]);
+
+export const FILTERS = ["none", "grayscale", "sepia"];
+
+export const filterToClass = new Map<string, string>([
+  ["none", ""],
+  ["grayscale", "grayscale"],
+  ["sepia", "sepia"],
+]);


### PR DESCRIPTION
## Changes
- Added filters to customize page
- Changed package to download as image; when downloading using `html2canvas-pro`, the filters don't apply for some reason
- Changed image download name so it's more unique and you're not getting something like `image(2).png` anymore
- Created class maps for filters and bg colors

## Notes
- For now we just have no filter, grayscale, and sepia, but we want to add more like a vintage filter and maybe some ones inspired by Korean photo booths

## Checklist before Merging
- [ ] Self reviewed?
- [x] Passes CI checks?